### PR TITLE
feat: 헤더, 푸터 커뮤니티 페이지 링크 연동, 및 main 태그 수정

### DIFF
--- a/src/pages/community/list/list-page-style.ts
+++ b/src/pages/community/list/list-page-style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const CommunityListPage = styled.main`
+const CommunityListPage = styled.section`
   display: flex;
   justify-content: center;
   width: 100%;

--- a/src/pages/community/post-detail/post-detail-page-style.ts
+++ b/src/pages/community/post-detail/post-detail-page-style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const PostDetailPage = styled.main`
+const PostDetailPage = styled.section`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/pages/community/post/post-page-style.ts
+++ b/src/pages/community/post/post-page-style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const PostPage = styled.main`
+const PostPage = styled.section`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/widgets/footer/footer.tsx
+++ b/src/widgets/footer/footer.tsx
@@ -37,10 +37,10 @@ const Footer = () => {
             <h5>Community</h5>
             <ul>
               <li>
-                <Link href='/'>All Posts</Link>
+                <Link href='/community/list'>All Posts</Link>
               </li>
               <li>
-                <Link href='/'>Popular Posts</Link>
+                <Link href='/community/list'>Popular Posts</Link>
               </li>
             </ul>
           </div>

--- a/src/widgets/header/header.tsx
+++ b/src/widgets/header/header.tsx
@@ -33,7 +33,7 @@ const Header = ({ isLoggedIn }: HeaderProps) => {
                 <Link href='/product'>중고거래</Link>
               </li>
               <li>
-                <Link href='/'>커뮤니티</Link>
+                <Link href='/community/list'>커뮤니티</Link>
               </li>
               <li>
                 <Link href='/'>반려동물동반</Link>


### PR DESCRIPTION
## 🛠️주요 변경 사항

- 헤더, 푸터 커뮤니티 페이지 링크 연동
- 커뮤니티 페이지 main 태그 section 태그로 변경

## 📣리뷰어가 꼭 알아야 하는 사항

- 깃허브에서 컨플릭 해결을 했는데, 헤더 부분 링크 달아뒀던게 날아갔네용. 잘못 건드렸나봐요! 다시 pr 올립니다!

## ❗관련이슈

- closed: #

## 🖼️스크린샷(선택)
